### PR TITLE
Remove '?' from query string in MeetingTimeDAO tests, VoteMeetingTimeDAO

### DIFF
--- a/GoMeet/src/main/webapp/js/vote-meeting-time-dao.js
+++ b/GoMeet/src/main/webapp/js/vote-meeting-time-dao.js
@@ -1,5 +1,5 @@
 class VoteMeetingTimeDAO {
-  static endpoint = '/vote-meeting-time?'; // Endpoint associated with this servlet.
+  static endpoint = '/vote-meeting-time'; // Endpoint associated with this servlet.
 
   /**
    * Increments the number of votes associated with the MeetingTime

--- a/GoMeet/src/main/webapp/test/spec/spec-meeting-time-dao.js
+++ b/GoMeet/src/main/webapp/test/spec/spec-meeting-time-dao.js
@@ -1,7 +1,7 @@
 describe('MeetingTimeDAO - fetchMeetingTime', function () {
   const MEETING_TIME_ID = 'abc123def456';
   const INVALID_ID = 'non-existent-id';
-  const QUERY_STRING = 'meetingTimeId=' + encodeURIComponent(MEETING_TIME_ID);
+  const QUERY_STRING = '?meetingTimeId=' + encodeURIComponent(MEETING_TIME_ID);
   const ERROR_RESPONSE = {
     status: 404,
     message: 'This will be an error message',
@@ -52,7 +52,7 @@ describe('MeetingTimeDAO - fetchMeetingTime', function () {
     let result = await MeetingTimeDAO.fetchMeetingTime(INVALID_ID);
     expect(result).toEqual(ERROR_RESPONSE);
     expect(window.fetch).toHaveBeenCalledWith(
-      MeetingTimeDAO.endpoint + 'meetingTimeId=' + INVALID_ID
+      MeetingTimeDAO.endpoint + '?meetingTimeId=' + INVALID_ID
     );
   });
 
@@ -75,7 +75,7 @@ describe('MeetingTimeDAO - newMeetingTime', function () {
   const DATETIME_STR = '2021-01-25T17:52';
   const INVALID_DATETIME_FORMAT = '25 January 2021, 5:25PM';
   const INVALID_DATETIME = '2021-01-33T17:52'; // No 33rd of January
-  const QUERY_STRING = 'datetime=' + encodeURIComponent(DATETIME_STR);
+  const QUERY_STRING = '?datetime=' + encodeURIComponent(DATETIME_STR);
   const RESPONSE_INIT = { // send to doPost not doGet
     method: 'POST'
   };

--- a/GoMeet/src/main/webapp/test/spec/spec-vote-meeting-time-dao.js
+++ b/GoMeet/src/main/webapp/test/spec/spec-vote-meeting-time-dao.js
@@ -23,11 +23,11 @@ describe('VoteMeetingTimeDAO - voteMeetingTime', function () {
   const MEETING_TIME_ID = 'abc123def456';
   const NON_EXISTENT_ID = 'non-existent-id';
   const VOTER = 'anna@test.com';
-  const QUERY_STRING = 'meetingTimeId=' 
+  const QUERY_STRING = '?meetingTimeId=' 
       + encodeURIComponent(MEETING_TIME_ID) 
       + '&voters=' 
       + encodeURIComponent(VOTER);
-  const INVALID_DATA_QUERY_STRING = 'meetingTimeId=' 
+  const INVALID_DATA_QUERY_STRING = '?meetingTimeId=' 
       + encodeURIComponent(NON_EXISTENT_ID) 
       + '&voters=' 
       + encodeURIComponent(VOTER);


### PR DESCRIPTION
This follows the refactoring of the DAOUtils.url function to add the '?' to the query string instead of including the '?' with each of the endpoints in the DAOs.