### PR TITLE
AutoProposeTimes class - Google Calendar Meeting Time Proposal 

### DIFF
--- a/GoMeet/pom.xml
+++ b/GoMeet/pom.xml
@@ -121,6 +121,19 @@
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
     </dependency>
+
+    <!-- Google Calendar -->
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.31.2</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-calendar</artifactId>
+      <version>v3-rev20201028-1.30.10</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
+++ b/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
@@ -1,7 +1,7 @@
 package com.google.sps.data;
 
-import com.google.api.client.util.DateTime;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.Calendar.Freebusy.Query;
 import com.google.api.services.calendar.Calendar.Freebusy;
 import com.google.api.services.calendar.Calendar;
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 public class AutoProposeTimes {
   private final String RFC3339_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";

--- a/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
+++ b/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
@@ -1,6 +1,17 @@
 package com.google.sps.data;
 
 import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar.Freebusy.Query;
+import com.google.api.services.calendar.Calendar.Freebusy;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.CalendarRequest;
+import com.google.api.services.calendar.model.FreeBusyCalendar;
+import com.google.api.services.calendar.model.FreeBusyRequest;
+import com.google.api.services.calendar.model.FreeBusyRequestItem;
+import com.google.api.services.calendar.model.FreeBusyResponse;
+import com.google.api.services.calendar.model.TimePeriod;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -30,5 +41,34 @@ public class AutoProposeTimes {
     this.startTime = new DateTime(startTime);
     this.endTime = new DateTime(endTime);
     this.meetingDuration = duration;
+  }
+
+  /**
+   * Makes a request to the Freebusy library of the Google Calendar API,
+   * and returns the List of TimePeriods representing busy times of the
+   * user between the startTime and endTime that this instance was 
+   * initialised with.
+   * @param calId The calendar identifier of the calendar to retireve busy
+   * data from.
+   * @param apiKey The API key to access the Google Calendar API.
+   * @return The List of TimePeriods representing busy times in the calendar
+   * identified by the calId.
+   * @throws IOException
+   * @throws GeneralSecurityException
+   */
+  public List<TimePeriod> freebusyRequest(String calId, String apiKey) 
+      throws IOException, GeneralSecurityException {
+    FreeBusyRequestItem currentCalItem = new FreeBusyRequestItem().setId(calId);
+    FreeBusyRequest req = new FreeBusyRequest()
+        .setTimeMin(this.startTime)
+        .setTimeMax(this.endTime)
+        .setItems(Arrays.asList(currentCalItem));
+    Freebusy freebusy = this.service.freebusy();
+    Query query = freebusy.query(req).setKey(apiKey);
+    FreeBusyResponse resp = query.execute();
+    // Variable 'currentCal' will store the FreeBusy info of the calendar
+    // with calId as its identifier.
+    FreeBusyCalendar currentCal = resp.getCalendars().get(calId); 
+    return currentCal.getBusy();
   }
 }

--- a/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
+++ b/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
@@ -20,9 +20,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 public class AutoProposeTimes {
   private final String RFC3339_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
+  private static String TIMEZONE = "AET"; // Australian Eastern Time
 
   Calendar service;
   String apiKey; 
@@ -48,8 +50,8 @@ public class AutoProposeTimes {
     this.service = service;
     this.apiKey = apiKey;
     this.calendarId = calId;
-    this.startTime = new DateTime(startTime);
-    this.endTime = new DateTime(endTime);
+    this.startTime = new DateTime(startTime, TimeZone.getTimeZone(TIMEZONE));
+    this.endTime = new DateTime(endTime, TimeZone.getTimeZone(TIMEZONE));
     this.meetingDuration = duration;
   }
 
@@ -155,7 +157,8 @@ public class AutoProposeTimes {
     FreeBusyRequest req = new FreeBusyRequest()
         .setTimeMin(this.startTime)
         .setTimeMax(this.endTime)
-        .setItems(Arrays.asList(currentCalItem));
+        .setItems(Arrays.asList(currentCalItem))
+        .setTimeZone(TIMEZONE); // The timezone that the times returned will be in.
     Freebusy freebusy = this.service.freebusy();
     Query query = freebusy.query(req).setKey(this.apiKey);
     FreeBusyResponse resp = query.execute();
@@ -163,6 +166,18 @@ public class AutoProposeTimes {
     // with calId as its identifier.
     FreeBusyCalendar currentCal = resp.getCalendars().get(calId); 
     return currentCal.getBusy();
+  }
+
+  /**
+   * Sets the timezone that the algorithm will be applying to times.
+   * Timezone is AET (Australian Eastern Time) by default.
+   * startTime and endTime provided to constructor will be assumed to be
+   * this timezone, all auto generated times will be returned in this timezone.
+   * @param timezoneString The string that represents the timezone.
+   * Must be one of the timezones as returned by TimeZone.getAvailableIDs()
+   */
+  public static void setTimezone(String timezone) {
+    TIMEZONE = timezone;
   }
 
   /**

--- a/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
+++ b/GoMeet/src/main/java/com/google/sps/data/AutoProposeTimes.java
@@ -1,0 +1,34 @@
+package com.google.sps.data;
+
+import com.google.api.client.util.DateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class AutoProposeTimes {
+  Calendar service;
+  ArrayList<String> calendarId; // The List of Calendar IDs to generate meeting times for
+  DateTime startTime; // The start time of the period to look for possible meeting times
+  DateTime endTime; // The end time of the period to look for possible meeting times
+  int meetingDuration; // The meetingDuration in milliseconds.
+
+   /**
+    * Constructor.
+    * NOTE: Calendar service is dependency injected to allow for easier testing.
+    * @param service The com.google.api.services.calendar.Calendar service to use to 
+    * call APIs from.
+    * @param calId This list of calendar IDs of calendars to automatically generate
+    * meeting times from.
+    * @param startTime The start of the period in which to search for meeting times.
+    * @param endTime The end of the period in which search for meeting times.
+    * @param duration The duration of the meeting, in milliseconds.
+    */
+  public AutoProposeTimes(Calendar service, ArrayList<String> calId, 
+      Date startTime, Date endTime, int duration) {
+    this.service = service;
+    this.calendarId = calId;
+    this.startTime = new DateTime(startTime);
+    this.endTime = new DateTime(endTime);
+    this.meetingDuration = duration;
+  }
+}

--- a/GoMeet/src/test/java/com/google/sps/AutoProposeTimesTest.java
+++ b/GoMeet/src/test/java/com/google/sps/AutoProposeTimesTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.TimeZone;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +48,7 @@ public class AutoProposeTimesTest {
   private final String FAKE_API_KEY = "key";
   private final int DURATION_MS = 30 * 60 * 1000; // 30 mins duration in milliseconds.
   private final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+  private final String TIMEZONE = "AET";
   private final SimpleDateFormat FORMATTER = new SimpleDateFormat(DATE_FORMAT);
   private final ArrayList<String> CAL_ID = 
       new ArrayList<String> (Arrays.asList("person1@test.com", "person2@test.com"));
@@ -78,6 +80,7 @@ public class AutoProposeTimesTest {
     // Initialise the Dates here to recognise the ParseException.
     startTime = FORMATTER.parse(START_TIME_STR);
     endTime = FORMATTER.parse(END_TIME_STR);
+    AutoProposeTimes.setTimezone(TIMEZONE);
     proposer = 
         new AutoProposeTimes(serviceSpy, FAKE_API_KEY, CAL_ID, startTime, endTime, DURATION_MS);
     proposerSpy = spy(proposer);
@@ -283,8 +286,11 @@ public class AutoProposeTimesTest {
   
   private TimePeriod timePeriodFromDatestring(String start, String end) 
       throws ParseException {
-    DateTime startDateTime = new DateTime(FORMATTER.parse(start));
-    DateTime endDateTime = new DateTime(FORMATTER.parse(end));
+    SimpleDateFormat formatter = new SimpleDateFormat(DATE_FORMAT);
+    DateTime startDateTime = 
+        new DateTime(FORMATTER.parse(start), TimeZone.getTimeZone(TIMEZONE));
+    DateTime endDateTime = 
+        new DateTime(FORMATTER.parse(end), TimeZone.getTimeZone(TIMEZONE));
     TimePeriod time = new TimePeriod()
         .setStart(startDateTime)
         .setEnd(endDateTime);

--- a/GoMeet/src/test/java/com/google/sps/AutoProposeTimesTest.java
+++ b/GoMeet/src/test/java/com/google/sps/AutoProposeTimesTest.java
@@ -44,6 +44,7 @@ public class AutoProposeTimesTest {
   private AutoProposeTimes proposerSpy;
 
   // Hardcoded data.
+  private final String FAKE_API_KEY = "key";
   private final int DURATION_MS = 30 * 60 * 1000; // 30 mins duration in milliseconds.
   private final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
   private final SimpleDateFormat FORMATTER = new SimpleDateFormat(DATE_FORMAT);
@@ -77,7 +78,8 @@ public class AutoProposeTimesTest {
     // Initialise the Dates here to recognise the ParseException.
     startTime = FORMATTER.parse(START_TIME_STR);
     endTime = FORMATTER.parse(END_TIME_STR);
-    proposer = new AutoProposeTimes(serviceSpy, CAL_ID, startTime, endTime, DURATION_MS);
+    proposer = 
+        new AutoProposeTimes(serviceSpy, FAKE_API_KEY, CAL_ID, startTime, endTime, DURATION_MS);
     proposerSpy = spy(proposer);
   }
 
@@ -96,9 +98,9 @@ public class AutoProposeTimesTest {
     );
 
     doReturn(busyTimesPerson1).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(0)));
     doReturn(busyTimesPerson2).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(1)));
 
     List<TimePeriod> expectedReturn = Arrays.asList(
       timePeriodFromDatestring(TIME_10AM, TIME_12PM),
@@ -126,9 +128,9 @@ public class AutoProposeTimesTest {
     );
 
     doReturn(busyTimesPerson1).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(0)));
     doReturn(busyTimesPerson2).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(1)));
 
     List<TimePeriod> expectedReturn = Arrays.asList(
       timePeriodFromDatestring(TIME_10AM, TIME_12PM),
@@ -155,9 +157,9 @@ public class AutoProposeTimesTest {
     );
 
     doReturn(busyTimesPerson1).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(0)));
     doReturn(busyTimesPerson2).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(1)));
 
     List<TimePeriod> expectedReturn = Arrays.asList(
       timePeriodFromDatestring(TIME_10AM, TIME_12PM),
@@ -188,9 +190,9 @@ public class AutoProposeTimesTest {
     );
 
     doReturn(busyTimesPerson1).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(0)));
     doReturn(busyTimesPerson2).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(1)));
 
     List<TimePeriod> expectedReturn = Arrays.asList(
       timePeriodFromDatestring(TIME_12PM, TIME_1230PM)
@@ -210,7 +212,7 @@ public class AutoProposeTimesTest {
     List<TimePeriod> busyTimes = Arrays.asList();
 
     doReturn(busyTimes).when(proposerSpy)
-        .freebusyRequest(anyString(), anyString());
+        .freebusyRequest(anyString());
 
     List<TimePeriod> expectedReturn = Arrays.asList(
       timePeriodFromDatestring(TIME_10AM, TIME_10AM_NEXTDAY)
@@ -239,9 +241,9 @@ public class AutoProposeTimesTest {
     );
 
     doReturn(busyTimesPerson1).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(0)));
     doReturn(busyTimesPerson2).when(proposerSpy)
-        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+        .freebusyRequest(eq(CAL_ID.get(1)));
 
     List<TimePeriod> expectedReturn = Arrays.asList();
     List<TimePeriod> result = proposerSpy.proposeTimes();
@@ -265,8 +267,8 @@ public class AutoProposeTimesTest {
   // Tests for freebusyRequest()
   @Test(expected = GoogleJsonResponseException.class)
   public void verifyCorrectAPICalls() throws Exception {
-    // This will throw an exception, since empty-string API key provided
-    proposer.freebusyRequest("test@example.com", "");
+    // This will throw an exception, since fake API key provided
+    proposer.freebusyRequest("test@example.com");
 
     // Verify that the correct API call was made
     FreeBusyRequestItem currentCalItem = 
@@ -276,7 +278,7 @@ public class AutoProposeTimesTest {
         .setTimeMax(new DateTime(endTime))
         .setItems(Arrays.asList(currentCalItem));
     
-    verify(serviceSpy).freebusy().query(req).setKey("").execute();
+    verify(serviceSpy).freebusy().query(req).setKey(FAKE_API_KEY).execute();
   }
   
   private TimePeriod timePeriodFromDatestring(String start, String end) 

--- a/GoMeet/src/test/java/com/google/sps/AutoProposeTimesTest.java
+++ b/GoMeet/src/test/java/com/google/sps/AutoProposeTimesTest.java
@@ -1,0 +1,291 @@
+package test.java.com.google.sps;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.FreeBusyRequest;
+import com.google.api.services.calendar.model.FreeBusyRequestItem;
+import com.google.api.services.calendar.model.TimePeriod;
+import com.google.gson.Gson;
+import com.google.sps.data.AutoProposeTimes;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for AutoProposeTimes class */
+@RunWith(JUnit4.class)
+public class AutoProposeTimesTest {
+  // Real objects.
+  private Calendar service;
+  private AutoProposeTimes proposer;
+
+  // Spies of the real objects.
+  private Calendar serviceSpy;
+  private AutoProposeTimes proposerSpy;
+
+  // Hardcoded data.
+  private final int DURATION_MS = 30 * 60 * 1000; // 30 mins duration in milliseconds.
+  private final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+  private final SimpleDateFormat FORMATTER = new SimpleDateFormat(DATE_FORMAT);
+  private final ArrayList<String> CAL_ID = 
+      new ArrayList<String> (Arrays.asList("person1@test.com", "person2@test.com"));
+  private final String START_TIME_STR = "2021-02-10 10:00:00";
+  private final String END_TIME_STR = "2021-02-11 10:00:00";
+  private final String TIME_10AM = "2021-02-10 10:00:00";
+  private final String TIME_12PM = "2021-02-10 12:00:00";
+  private final String TIME_1230PM = "2021-02-10 12:30:00";
+  private final String TIME_1PM = "2021-02-10 13:00:00";
+  private final String TIME_2PM = "2021-02-10 14:00:00";
+  private final String TIME_4PM = "2021-02-10 16:00:00";
+  private final String TIME_6PM = "2021-02-10 18:00:00"; 
+  private final String TIME_8PM = "2021-02-10 20:00:00"; 
+  private final String TIME_10PM = "2021-02-10 22:00:00"; 
+  private final String TIME_8AM_NEXTDAY = "2021-02-11 08:00:00";
+  private final String TIME_10AM_NEXTDAY = "2021-02-11 10:00:00";
+
+  private Date startTime;
+  private Date endTime;
+
+  @Before
+  public void setup() throws GeneralSecurityException, IOException, ParseException {
+    service = new Calendar.Builder(GoogleNetHttpTransport.newTrustedTransport(),
+        GsonFactory.getDefaultInstance(),
+        null)
+        .setApplicationName("GoMeet")
+        .build();
+    serviceSpy = spy(service);
+    // Initialise the Dates here to recognise the ParseException.
+    startTime = FORMATTER.parse(START_TIME_STR);
+    endTime = FORMATTER.parse(END_TIME_STR);
+    proposer = new AutoProposeTimes(serviceSpy, CAL_ID, startTime, endTime, DURATION_MS);
+    proposerSpy = spy(proposer);
+  }
+
+  /** Tests for proposeTimes */
+
+  // The events of the two guests are separate in the day
+  @Test
+  public void separateBusyPeriods() throws Exception {
+    List<TimePeriod> busyTimesPerson1 = Arrays.asList(
+      timePeriodFromDatestring(TIME_4PM, TIME_6PM),
+      timePeriodFromDatestring(TIME_8AM_NEXTDAY, TIME_10AM_NEXTDAY)
+    );
+    List<TimePeriod> busyTimesPerson2 = Arrays.asList(
+      timePeriodFromDatestring(TIME_12PM, TIME_2PM),
+      timePeriodFromDatestring(TIME_8PM, TIME_10PM)
+    );
+
+    doReturn(busyTimesPerson1).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+    doReturn(busyTimesPerson2).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+
+    List<TimePeriod> expectedReturn = Arrays.asList(
+      timePeriodFromDatestring(TIME_10AM, TIME_12PM),
+      timePeriodFromDatestring(TIME_2PM, TIME_4PM),
+      timePeriodFromDatestring(TIME_6PM, TIME_8PM),
+      timePeriodFromDatestring(TIME_10PM, TIME_8AM_NEXTDAY)
+    );
+
+    List<TimePeriod> result = proposerSpy.proposeTimes();
+
+    // Assert list sizes are the same
+    assertEquals(expectedReturn.size(), result.size());
+    // Assert that both expected return and actual result are the same
+    assertTrue(result.equals(expectedReturn));
+  }
+
+  // The busy periods of the guests overlap
+  @Test
+  public void overlappingBusyPeriods() throws Exception {
+    List<TimePeriod> busyTimesPerson1 = Arrays.asList(
+      timePeriodFromDatestring(TIME_1PM, TIME_2PM)
+    );
+    List<TimePeriod> busyTimesPerson2 = Arrays.asList(
+      timePeriodFromDatestring(TIME_12PM, TIME_2PM)
+    );
+
+    doReturn(busyTimesPerson1).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+    doReturn(busyTimesPerson2).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+
+    List<TimePeriod> expectedReturn = Arrays.asList(
+      timePeriodFromDatestring(TIME_10AM, TIME_12PM),
+      timePeriodFromDatestring(TIME_2PM, TIME_10AM_NEXTDAY)
+    );
+
+    List<TimePeriod> result = proposerSpy.proposeTimes();
+
+    // Assert list sizes are the same
+    assertEquals(expectedReturn.size(), result.size());
+    // Assert that both expected return and actual result are the same
+    assertTrue(result.equals(expectedReturn));
+  }
+
+  @Test
+  public void nestedEvents() throws Exception {
+    List<TimePeriod> busyTimesPerson1 = Arrays.asList(
+      // This event is nested in the 12PM-4PM event of person2.
+      timePeriodFromDatestring(TIME_1PM, TIME_2PM),
+      timePeriodFromDatestring(TIME_6PM, TIME_8PM)
+    );
+    List<TimePeriod> busyTimesPerson2 = Arrays.asList(
+      timePeriodFromDatestring(TIME_12PM, TIME_4PM)
+    );
+
+    doReturn(busyTimesPerson1).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+    doReturn(busyTimesPerson2).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+
+    List<TimePeriod> expectedReturn = Arrays.asList(
+      timePeriodFromDatestring(TIME_10AM, TIME_12PM),
+      timePeriodFromDatestring(TIME_4PM, TIME_6PM),
+      timePeriodFromDatestring(TIME_8PM, TIME_10AM_NEXTDAY)
+    );
+
+    List<TimePeriod> result = proposerSpy.proposeTimes();
+
+    // Assert list sizes are the same
+    assertEquals(expectedReturn.size(), result.size());
+    // Assert that both expected return and actual result are the same
+    assertTrue(result.equals(expectedReturn));
+  }
+
+  // Only one time slot possible considering all the busy periods
+  @Test
+  public void justEnoughRoom() throws Exception {
+    List<TimePeriod> busyTimesPerson1 = Arrays.asList(
+      timePeriodFromDatestring(TIME_10AM, TIME_12PM),
+      timePeriodFromDatestring(TIME_2PM, TIME_8PM),
+      timePeriodFromDatestring(TIME_10PM, TIME_10AM_NEXTDAY)
+    );
+    List<TimePeriod> busyTimesPerson2 = Arrays.asList(
+      timePeriodFromDatestring(TIME_1230PM, TIME_2PM),
+      timePeriodFromDatestring(TIME_1230PM, TIME_2PM),
+      timePeriodFromDatestring(TIME_8PM, TIME_10PM)
+    );
+
+    doReturn(busyTimesPerson1).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+    doReturn(busyTimesPerson2).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+
+    List<TimePeriod> expectedReturn = Arrays.asList(
+      timePeriodFromDatestring(TIME_12PM, TIME_1230PM)
+    );
+
+    List<TimePeriod> result = proposerSpy.proposeTimes();
+
+    // Assert list sizes are the same
+    assertEquals(expectedReturn.size(), result.size());
+    // Assert that both expected return and actual result are the same
+    assertTrue(result.equals(expectedReturn));
+  }
+
+  // No busy periods detected for all guests across the time period
+  @Test
+  public void noBusyPeriods() throws Exception {
+    List<TimePeriod> busyTimes = Arrays.asList();
+
+    doReturn(busyTimes).when(proposerSpy)
+        .freebusyRequest(anyString(), anyString());
+
+    List<TimePeriod> expectedReturn = Arrays.asList(
+      timePeriodFromDatestring(TIME_10AM, TIME_10AM_NEXTDAY)
+    );
+
+    List<TimePeriod> result = proposerSpy.proposeTimes();
+
+    // Assert list sizes are the same
+    assertEquals(expectedReturn.size(), result.size());
+    // Assert that both expected return and actual result are the same
+    assertTrue(result.equals(expectedReturn));
+  }
+
+  // No timeslots long enough for the meeting to occur
+  @Test
+  public void notEnoughRoom() throws Exception {
+    List<TimePeriod> busyTimesPerson1 = Arrays.asList(
+      timePeriodFromDatestring(TIME_10AM, TIME_12PM),
+      timePeriodFromDatestring(TIME_2PM, TIME_8PM),
+      timePeriodFromDatestring(TIME_10PM, TIME_10AM_NEXTDAY)
+    );
+    List<TimePeriod> busyTimesPerson2 = Arrays.asList(
+      timePeriodFromDatestring(TIME_12PM, TIME_2PM),
+      timePeriodFromDatestring(TIME_1230PM, TIME_2PM),
+      timePeriodFromDatestring(TIME_8PM, TIME_10PM)
+    );
+
+    doReturn(busyTimesPerson1).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(0)), anyString());
+    doReturn(busyTimesPerson2).when(proposerSpy)
+        .freebusyRequest(eq(CAL_ID.get(1)), anyString());
+
+    List<TimePeriod> expectedReturn = Arrays.asList();
+    List<TimePeriod> result = proposerSpy.proposeTimes();
+
+    // Assert list sizes are the same
+    assertEquals(expectedReturn.size(), result.size());
+    // Assert that both expected return and actual result are the same
+    assertTrue(result.equals(expectedReturn));
+  }
+
+  // Throws GoogleJsonResponseException on API errors (e.g. invalid key).
+  @Test(expected = GoogleJsonResponseException.class)
+  public void throwsErrorOnAPIFailure() throws Exception {
+    // Do NOT stub the freebusyRequest function - call through the 
+    // proposeTimes() function on the real 'proposer'. 
+    // There is no API key provided in these tests, so API calls 
+    // should return an error.
+    List<TimePeriod> result = proposer.proposeTimes();
+  }
+
+  // Tests for freebusyRequest()
+  @Test(expected = GoogleJsonResponseException.class)
+  public void verifyCorrectAPICalls() throws Exception {
+    // This will throw an exception, since empty-string API key provided
+    proposer.freebusyRequest("test@example.com", "");
+
+    // Verify that the correct API call was made
+    FreeBusyRequestItem currentCalItem = 
+        new FreeBusyRequestItem().setId("test@example.com");
+    FreeBusyRequest req = new FreeBusyRequest()
+        .setTimeMin(new DateTime(startTime))
+        .setTimeMax(new DateTime(endTime))
+        .setItems(Arrays.asList(currentCalItem));
+    
+    verify(serviceSpy).freebusy().query(req).setKey("").execute();
+  }
+  
+  private TimePeriod timePeriodFromDatestring(String start, String end) 
+      throws ParseException {
+    DateTime startDateTime = new DateTime(FORMATTER.parse(start));
+    DateTime endDateTime = new DateTime(FORMATTER.parse(end));
+    TimePeriod time = new TimePeriod()
+        .setStart(startDateTime)
+        .setEnd(endDateTime);
+    return time;
+  }
+}


### PR DESCRIPTION
Implementation for the class to that calls the Google Calendar API and generates meeting times.

proposeTimes function uses the following algorithm to analyse a list of TimePeriods representing busy times:

1. Sort the list of TimePeriods in order of earliest to latest start time
2. Scanning over the list of TimePeriod with two  pointers:
    If the end of the current time period (pointed to by left pointer) overlaps with the start of the next time period, move the right pointer one item to the right.
    Otherwise, check the duration of the free time block from the end of the current time period to the start of the next time period.
        If the duration is at least the meeting duration, add to output.
        Move the left pointer to the right pointer (i.e. current is now what the right pointer was pointing to.)

The algorithm time complexity is bounded by the sort of the time periods, O(Nlog(N)), where N is the number of busy TimePeriods in total retrieved from each of the invitees' calendars.