### PR TITLE
Handle bad request response status

### DIFF
--- a/GoMeet/src/main/java/com/google/sps/data/ErrorMessages.java
+++ b/GoMeet/src/main/java/com/google/sps/data/ErrorMessages.java
@@ -12,7 +12,7 @@ public class ErrorMessages {
       "Too many results returned";
   public static final String REPEAT_TITLE_ERROR = 
       "There is already a location with this title";
-  public static final String MAX_ENTITIES = 
+  public static final String MAX_ENTITIES_ERROR = 
       "Maximum number of entities reached";
   public static final String BAD_EMAIL_REQUEST_ERROR = 
       "MeetingId and guest list must both be provided to send email invitations";

--- a/GoMeet/src/main/java/com/google/sps/data/ErrorMessages.java
+++ b/GoMeet/src/main/java/com/google/sps/data/ErrorMessages.java
@@ -11,7 +11,7 @@ public class ErrorMessages {
   public static final String TOO_MANY_RESULTS_ERROR = 
       "Too many results returned";
   public static final String BAD_REQUEST_ERROR_LOCATION = 
-      "Invalid location";
+      "There is already a location with this title";
   public static final String MAX_ENTITIES = 
       "Maximum number of entities reached";
   public static final String BAD_EMAIL_REQUEST_ERROR = 

--- a/GoMeet/src/main/java/com/google/sps/data/ErrorMessages.java
+++ b/GoMeet/src/main/java/com/google/sps/data/ErrorMessages.java
@@ -10,7 +10,7 @@ public class ErrorMessages {
       "Entity not found";
   public static final String TOO_MANY_RESULTS_ERROR = 
       "Too many results returned";
-  public static final String BAD_REQUEST_ERROR_LOCATION = 
+  public static final String REPEAT_TITLE_ERROR = 
       "There is already a location with this title";
   public static final String MAX_ENTITIES = 
       "Maximum number of entities reached";

--- a/GoMeet/src/main/java/com/google/sps/servlets/LocationServlet.java
+++ b/GoMeet/src/main/java/com/google/sps/servlets/LocationServlet.java
@@ -58,7 +58,7 @@ public class LocationServlet extends HttpServlet {
       response.getWriter().println(json);
     } catch (SimilarEntityExistsException e) {
       ServletUtil.sendErrorResponse(
-          response, HttpServletResponse.SC_BAD_REQUEST, ErrorMessages.BAD_REQUEST_ERROR_LOCATION);
+          response, HttpServletResponse.SC_BAD_REQUEST, ErrorMessages.REPEAT_TITLE_ERROR);
     } catch (MaxEntitiesReachedException e) {
       ServletUtil.sendErrorResponse(
           response, HttpServletResponse.SC_BAD_REQUEST, ErrorMessages.MAX_ENTITIES);

--- a/GoMeet/src/main/java/com/google/sps/servlets/LocationServlet.java
+++ b/GoMeet/src/main/java/com/google/sps/servlets/LocationServlet.java
@@ -61,7 +61,7 @@ public class LocationServlet extends HttpServlet {
           response, HttpServletResponse.SC_BAD_REQUEST, ErrorMessages.REPEAT_TITLE_ERROR);
     } catch (MaxEntitiesReachedException e) {
       ServletUtil.sendErrorResponse(
-          response, HttpServletResponse.SC_BAD_REQUEST, ErrorMessages.MAX_ENTITIES);
+          response, HttpServletResponse.SC_BAD_REQUEST, ErrorMessages.MAX_ENTITIES_ERROR);
     }
   }
 

--- a/GoMeet/src/main/webapp/js/meeting-location-dao.js
+++ b/GoMeet/src/main/webapp/js/meeting-location-dao.js
@@ -135,7 +135,8 @@ class PermMeetingLocationDao {
   /** 
    * Sends a new location to the servlet.
    * @return {String} Key String from the servlet.
-   * Throws an error if title is blank.
+   * @throws an error if title is blank.
+   * @throws an error if the server responds with BAD_REQUEST.
    */
   async newLocation(title, lat, lng, note) {
     if (title === '') {
@@ -147,8 +148,12 @@ class PermMeetingLocationDao {
     params.append('lng', lng);
     params.append('note', note);
     let response = await fetch(this.storingEndPoint, {method: 'POST', body: params});
-    let result = await response.json();
-    return result;
+    let json = await response.json();
+    if (response.status >= 200 && response.status <= 299) {
+      return json;
+    } else {
+      throw new Error(json.message);
+    }
   }
 
   /** Sends a request to the servlet to update a location entity's voteCount.

--- a/GoMeet/src/main/webapp/test/spec/spec-meeting-location-dao.js
+++ b/GoMeet/src/main/webapp/test/spec/spec-meeting-location-dao.js
@@ -64,6 +64,8 @@ describe('New Location', function() {
   const LNG_A = 15.0; 
   const NOTE_A = 'I like Tacos';
   const KEY_STRING = '1234';
+  const BAD_REQUEST_RESPONSE =
+      {status : 400, message : 'Invalid Location'};
 
   it ('Should send a post request with the correct params', async function() {
     // Set up fake promise to return 
@@ -104,6 +106,24 @@ describe('New Location', function() {
       errorMessage = error.message;
     }
     expect(errorMessage).toEqual(BLANK_FIELDS_ALERT);
+  });
+
+  it ('Should throw an error if response status is not between 200 and 299', 
+      async function() {
+    // Spy on Fetch API.
+    const fetchResultSpy = jasmine.createSpyObj('Response', ['json'], {status : 400});
+    fetchResultSpy.json.and.callFake(function() {
+      return BAD_REQUEST_RESPONSE;
+    });
+    spyOn(window, 'fetch').and.returnValue(fetchResultSpy);
+    
+    let errorMessage;
+    try {
+      await new PermMeetingLocationDao().newLocation(TITLE_A, LAT_A, LNG_A, NOTE_A);
+    } catch (error) {
+      errorMessage = error.message;
+    }
+    expect(errorMessage).toBe(BAD_REQUEST_RESPONSE.message);
   });
 });
 

--- a/GoMeet/src/test/java/com/google/sps/LocationServletTest.java
+++ b/GoMeet/src/test/java/com/google/sps/LocationServletTest.java
@@ -186,7 +186,7 @@ public class LocationServletTest {
 
     // Check hashmap with the correct values was sent.
     assertEquals((Double) map.get("status"), Double.valueOf(HttpServletResponse.SC_BAD_REQUEST));
-    assertEquals((String) map.get("message"), ErrorMessages.BAD_REQUEST_ERROR_LOCATION);
+    assertEquals((String) map.get("message"), ErrorMessages.REPEAT_TITLE_ERROR);
   }
 
   /** 

--- a/GoMeet/src/test/java/com/google/sps/LocationServletTest.java
+++ b/GoMeet/src/test/java/com/google/sps/LocationServletTest.java
@@ -153,7 +153,7 @@ public class LocationServletTest {
 
     // Check hashmap with the correct values was sent.
     assertEquals((Double) map.get("status"), Double.valueOf(HttpServletResponse.SC_BAD_REQUEST));
-    assertEquals((String) map.get("message"), ErrorMessages.MAX_ENTITIES);
+    assertEquals((String) map.get("message"), ErrorMessages.MAX_ENTITIES_ERROR);
   }
 
    /**


### PR DESCRIPTION
Handle Bad Request Response Status. 

An alert is created when a response is received and the Response.status is not OK. 

I chose to check the response.status in the ```PermMeetingLocationDao``` class so that if there are any changes to how the data is sent to the server/data is received from the server, the functions that update the DOM (in  ```interactive-map.js```) do not have to be changed as they only catch an error.

While, for now, I think handling errors the same way is okay, the handleError() function could be updated to display errors differently depending on the type.
